### PR TITLE
searchAliases function: cultureKey replacement fix

### DIFF
--- a/core/components/customrequest/model/customrequest/customrequest.class.php
+++ b/core/components/customrequest/model/customrequest/customrequest.class.php
@@ -249,7 +249,7 @@ class CustomRequest
     public function searchAliases($search)
     {
         // strip cultureKey i.e. in Babel installations.
-        $search = preg_replace('#' . $this->modx->cultureKey . '/(.*)#i', '$1', $search);
+        $search = ltrim($search, $this->modx->cultureKey.'/');
 
         $valid = false;
         // loop through the allowed aliases


### PR DESCRIPTION
Small change on CultureKey replacement. Now, if parent resources URI ends with the same characters as CultureKey, plugin gives 404 error anyway. For example, in case of analysen/articles/, plugin strips the en/ characters and gives wrong alias path, analysarticles/. My suggestion is to use ltrim(), because CultureKey is usually located right after the hostname.
