### PR TITLE
Fix RegEx evaluation

### DIFF
--- a/core/components/customrequest/model/customrequest/customrequest.class.php
+++ b/core/components/customrequest/model/customrequest/customrequest.class.php
@@ -288,7 +288,11 @@ class CustomRequest
     {
         $params = str_replace('.html', '', $this->urlParams);
         if ($this->regEx) {
-            $params = preg_match($this->regEx, $params);
+            if (!preg_match($this->regEx, $params, $matches)) {
+                return; // return without redirecting
+            }
+            array_shift($matches); // $matches[0] contains the full match, we don't want that
+            $params = $matches;
         } else {
             $params = explode('/', trim($params, '/'));
         }


### PR DESCRIPTION
How did the RegEx functionality ever work? It seems to me that it was totally broken (since `preg_match` does not return the matched groups), so I fixed it.

What I did not fix in this PR is the example in the README: `preg_match` expects a delimiter in the regex string, so `(.*?)-(\d+)` won't work, but e.g. `#(.*?)-(\d+)#` will (see http://stackoverflow.com/questions/5589807/preg-match-unknown-modifier).
