### PR TITLE
Fix $requestUri when modx in subfolder

### DIFF
--- a/core/components/customrequest/elements/plugins/customrequest.plugin.php
+++ b/core/components/customrequest/elements/plugins/customrequest.plugin.php
@@ -16,7 +16,8 @@ $customrequest = $modx->getService('customrequest', 'CustomRequest', $corePath .
     'core_path' => $corePath
 ));
 
-$requestUri = trim(strtok($_SERVER['REQUEST_URI'], '?'), '/');
+$requestParamAlias = $modx->getOption('request_param_alias', null, 'q');
+$requestUri = trim(strtok($_REQUEST[$requestParamAlias], '?'), '/');
 
 switch ($eventName) {
     case 'OnSiteRefresh':


### PR DESCRIPTION
My dev enviro has multiple modx installs in simple sub-folders (not virtualhost) with furl's enabled.

Experienced issues with CustomRequest and regex alias which I tracked down to using `$_SERVER['REQUEST_URI']` as the request source.

`$_SERVER['REQUEST_URI']` included the sub-folder at the beginning which meant it wasn't found in the alias map when searched here https://github.com/Jako/CustomRequest/blob/master/core/components/customrequest/model/customrequest/customrequest.class.php#L279. 

Changing `$requestUri` to the request query (same as tagger) resolved this.

Resolves #8 