### PR TITLE
Add colon for correct 'hit' on array key

### DIFF
--- a/core/components/customrequest/model/customrequest/customrequest.class.php
+++ b/core/components/customrequest/model/customrequest/customrequest.class.php
@@ -332,7 +332,7 @@ class CustomRequest
             $params = explode('/', trim($params, '/'));
         }
         if (count($params) >= 1) {
-            $setting = $this->requests[$this->found['contextKey'] . $this->found['alias']];
+            $setting = $this->requests[$this->found['contextKey'] . ":" . $this->found['alias']];
 
             $foundParams = array();
             // Set the request parameters


### PR DESCRIPTION
Following the latest update my values weren't getting added to the correct field names and were instead being put in p1, p2 etc.

At line 224 the requests are set with array keys that include a colon (this update was in commit https://github.com/Jako/CustomRequest/commit/44385f0f073613a4c8f928abf00c0f968ea27d1a).

Line 335 that 'picks up' the hit setting also needs a colon to pick the settings from the array, otherwise it will always register a 'miss' and collect no settings.